### PR TITLE
[Fix] Make command fails 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 test: test.c fft.c fft.h
-	gcc test.c fft.c -o test
+	gcc test.c fft.c -o test -lm


### PR DESCRIPTION
returns 
`gcc test.c fft.c -o test
/usr/bin/ld: /tmp/cckg4qu1.o: in function `main':
test.c:(.text+0x8e): undefined reference to `cabs'
/usr/bin/ld: test.c:(.text+0x112): undefined reference to `cabs'
/usr/bin/ld: test.c:(.text+0x1ea): undefined reference to `cabs'
/usr/bin/ld: test.c:(.text+0x278): undefined reference to `cabs'
/usr/bin/ld: test.c:(.text+0x2f8): undefined reference to `cabs'
/usr/bin/ld: /tmp/cckg4qu1.o:test.c:(.text+0x37c): more undefined references to `cabs' follow
/usr/bin/ld: /tmp/cc36MM40.o: in function `fft_slow':
fft.c:(.text+0x101): undefined reference to `cexp'
/usr/bin/ld: /tmp/cc36MM40.o: in function `fft_radix2':
fft.c:(.text+0x2fc): undefined reference to `cexp'
/usr/bin/ld: fft.c:(.text+0x413): undefined reference to `cexp'
collect2: error: ld returned 1 exit status
make: *** [Makefile:2: test] Error 1
`
without the `-lm` flag. Usually one puts the libraries after the file: linking is a fill in the gaps kind of deal, so you want the gap to exist first, before you fill it,
